### PR TITLE
with.zonayed.me/bn link removed because this site not exist.

### DIFF
--- a/blog-list.md
+++ b/blog-list.md
@@ -56,4 +56,3 @@
 - [হাসান আবদুল্লাহ](http://hellohasan.com/)
 - [হাসিন হায়দার](https://hasin.me/)
 - [দিবাকর সূত্রধর](https://with.dibakar.me/)
-- [জুনায়েদ আহমেদ](https://with.zonayed.me/bn)


### PR DESCRIPTION
The message showed when entered through the URL:-

Page Not Found
Looks like you've followed a broken link or entered a URL that doesn't exist on this site.